### PR TITLE
Fix clean drafts conditions

### DIFF
--- a/src/Model/Behavior/DraftBehavior.php
+++ b/src/Model/Behavior/DraftBehavior.php
@@ -15,8 +15,8 @@ class DraftBehavior extends Behavior
      * @var array $config
      */
     public $config = [
-            'conditions' => ['online' => -1]
-        ];
+        'conditions' => ['online' => -1]
+    ];
 
     /**
      * Initialize Draft Behavior.
@@ -72,6 +72,6 @@ class DraftBehavior extends Behavior
      */
     public function cleanDrafts(Table $table)
     {
-        return $table->deleteAll($this->config['conditions']);
+        return $table->deleteAll($this->config[$table->getAlias()]['conditions']);
     }
 }

--- a/src/Model/Behavior/DraftBehavior.php
+++ b/src/Model/Behavior/DraftBehavior.php
@@ -72,6 +72,6 @@ class DraftBehavior extends Behavior
      */
     public function cleanDrafts(Table $table)
     {
-        return $table->deleteAll(['online' => -1]);
+        return $table->deleteAll($this->config['conditions']);
     }
 }


### PR DESCRIPTION
The cleanDrafts function delete all content with the default condition:
`return $table->deleteAll(['online' => -1]);`
But we've to take in consideration of the user configuration condition:
`return $table->deleteAll($this->config[$table->getAlias()]['conditions']);`